### PR TITLE
Fail selftests when checksum file is missing in FIPS mode only

### DIFF
--- a/src/fips.c
+++ b/src/fips.c
@@ -613,7 +613,11 @@ check_binary_integrity (void)
               /* Open the file.  */
               fp = fopen (fname, "r");
               if (!fp)
-                err = gpg_error_from_syserror ();
+	        {
+		  /* Missing checksum is a problem only in FIPS mode */
+		  if (fips_mode() || errno != ENOENT)
+		    err = gpg_error_from_syserror ();
+	        }
               else
                 {
                   /* A buffer of 64 bytes plus one for a LF and one to


### PR DESCRIPTION
Libgcrypt runs self-check including hmac based binary verification outside FIPS mode and breaks keepassxc. See SUSE bug in https://bugzilla.opensuse.org/show_bug.cgi?id=1117355