### PR TITLE
Fix libgcrypt returning errno 2 (file not found)

### DIFF
--- a/src/fips.c
+++ b/src/fips.c
@@ -137,9 +137,11 @@ _gcry_initialize_fips_mode (int force)
   {
     static const char procfname[] = "/proc/sys/crypto/fips_enabled";
     FILE *fp;
-    int saved_errno;
-
+    int saved_errno = errno;
+    /* since procfname may not exist and that's okay, we should ignore
+       any changes that fopen does to errno. */
     fp = fopen (procfname, "r");
+    errno = saved_errno;
     if (fp)
       {
         char line[256];
@@ -197,9 +199,11 @@ _gcry_initialize_fips_mode (int force)
         }
 
 
+      int saved_errno = errno; /* since FIPS_FORCE_FILE may not exist, we ignore any error set by fopen */
       /* If the FIPS force files exists, is readable and has a number
          != 0 on its first line, we enable the enforced fips mode.  */
       fp = fopen (FIPS_FORCE_FILE, "r");
+      errno = saved_errno;
       if (fp)
         {
           char line[256];


### PR DESCRIPTION
I was coding with libcurl and decided to debug my code with a watchpoint on errno, to my unpleasent surprise, I found that libgcrypt was returning an error.
So I investigated the reason why, apparently, it was trying to open a file that doesn't exist, now /etc/gcrypt/fips_enabled doesn't actually *need* to exist by design, so libgcrypt should not change errno if it doesn't exist. 