### PR TITLE
Libgcrypt shouldn't return ENOENT when fips mode is disabled

### DIFF
--- a/src/fips.c
+++ b/src/fips.c
@@ -137,9 +137,11 @@ _gcry_initialize_fips_mode (int force)
   {
     static const char procfname[] = "/proc/sys/crypto/fips_enabled";
     FILE *fp;
-    int saved_errno;
-
+    int saved_errno = errno;
+    /* since procfname may not exist and that's okay, we should ignore
+       any changes that fopen does to errno. */
     fp = fopen (procfname, "r");
+    errno = saved_errno;
     if (fp)
       {
         char line[256];
@@ -197,9 +199,11 @@ _gcry_initialize_fips_mode (int force)
         }
 
 
+      int saved_errno = errno; /* since FIPS_FORCE_FILE may not exist, we ignore any error set by fopen */
       /* If the FIPS force files exists, is readable and has a number
          != 0 on its first line, we enable the enforced fips mode.  */
       fp = fopen (FIPS_FORCE_FILE, "r");
+      errno = saved_errno;
       if (fp)
         {
           char line[256];


### PR DESCRIPTION
In order to probe if fips_mode is enabled in the operating system, libgcrypt will try to fopen "/proc/sys/crypto/fips_enabled", now according to libgcrypt documentation, this file may not exist...
If it doesn't, then libgcrypt fallsback to "/etc/gcrypt/fips_enabled", it will again try to fopen it.
This procedure is described here: https://www.gnupg.org/documentation/manuals/gcrypt/Enabling-FIPS-mode.html
The key point here is that the relevant portion of code is using fopen to probe for the existence of the file, this may return all sorts of errors, but commonly it's ENOENT. which is then returned into any code that is initializing libgcrypt. But, I'm getting errno at something that is not an error, rather, a configuration detail, the fact that the file doesn't exist just means that libgcrypt should disable fips mode internally.