### PR TITLE
random-drbg: fix missing error check from _gcry_rngdrbg_cavs_test()

### DIFF
--- a/random/random-drbg.c
+++ b/random/random-drbg.c
@@ -2385,7 +2385,8 @@ _gcry_rngdrbg_healthcheck_one (struct gcry_drbg_test_vector * test)
 
   ret = _gcry_rngdrbg_cavs_test (test, buf);
   /* FIXME: The next line is wrong.   */
-  ret = memcmp (test->expected, buf, test->expectedlen);
+  if (ret == 0)
+    ret = memcmp (test->expected, buf, test->expectedlen);
 
   xfree (buf);
   return ret;


### PR DESCRIPTION
The return value of `_gcry_rngdrbg_cavs_test()` was immediately overwritten by `memcmp()` result, leading to potential loss of error information. This could cause the health check to succeed even if the internal CAVS test function failed.

This issue was reported by a static analyzer:
> Return value of function '_gcry_rngdrbg_cavs_test' passed to 'ret'
> at random-drbg.c:2378 will be rewritten later.

To fix this, we now check the return code of `_gcry_rngdrbg_cavs_test()` and only call `memcmp()` if the test execution succeeded.